### PR TITLE
Add test coverage via babel-istanbul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ lint:
 
 test: lint
 	@echo "\nTesting source files, hang on..."
-	@NODE_ENV=test $(BIN)/mocha          \
-		--require babel-register \
-		--require lib/__tests__/testdom    \
+	@NODE_ENV=test $(BIN)/babel-istanbul cover  \
+		./node_modules/mocha/bin/_mocha --        \
+		--require lib/__tests__/testdom           \
 		./lib/__tests__/*.test.js
 
 test-build:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
     "babel-eslint": "^5.0.0-beta6",
+    "babel-istanbul": "^0.6.0",
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Your readme lists test coverage as a todo, and we're depending on this project in a project I'm working on, so I figured I'd send you a PR with [babel-istanbul](https://github.com/ambitioninc/babel-istanbul) hooked up :smiley:

It was actually a bit tricky to get it to play nicely with Make, so you might find the test command somewhat cryptic, but unfortunately this was out of necessity.

Thank you so much for the awesome work!