### PR TITLE
Send coverage to Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - '4.2'
   - '4.0'
+after_script:
+  - make coveralls

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,12 @@ test-build:
 		--require dist/__tests__/testdom  \
 		./dist/__tests__/*.test.js
 
+coveralls:
+	@cat ./coverage/lcov.info | $(BIN)/coveralls
+
 clean:
 	@rm -rf ./dist
+	@rm -rf ./coverage
 
 build: test clean dist test-build
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-register": "^6.3.13",
+    "coveralls": "^2.11.6",
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^3.3.1",
     "express": "^4.13.3",


### PR DESCRIPTION
This change first requires logging in to [coveralls.io](http://coveralls.io/) and enabling this repo, but then builds on Travis CI will start sending coverage reports.