### PR TITLE
Fix #11 - add support for objects passed to link

### DIFF
--- a/lib/__tests__/dom.basic.test.js
+++ b/lib/__tests__/dom.basic.test.js
@@ -24,6 +24,10 @@ describe('DocumentMeta - DOM basic', () => {
         stylesheet: [
           'http://domain.tld/css/vendor.css',
           'http://domain.tld/css/styles.css'
+        ],
+        alternate: [
+          { href: '/alternate/us', hreflang: 'en-us' },
+          { href: '/alternate/gb', hreflang: 'en-gb' }
         ]
       }
     }
@@ -58,11 +62,18 @@ describe('DocumentMeta - DOM basic', () => {
   });
 
   it('should render normal link tags, eg. <link rel="..." href="...">', () => {
-    Object.keys( DOC_META.link.rel ).reduce(( rel ) => {
+    Object.keys( DOC_META.link.rel ).forEach(( rel ) => {
       const values = Array.isArray(DOC_META.link.rel[rel]) ? DOC_META.link.rel[rel] : [ DOC_META.link.rel[rel] ];
       const elements = getElements( `link[rel=${ rel }]` );
-      elements.forEach(( element, idx ) => {
-        assert.strictEqual( element.getAttribute('content'), values[idx], `<link rel="${ rel }" ... /> has not been rendered correctly` );
+      Object.keys(elements).forEach(( idx ) => {
+        const element = elements[idx];
+        if (typeof values[idx] === 'string') {
+          assert.strictEqual( element.getAttribute('href'), values[idx], `<link rel="${ rel }" ... /> has not been rendered correctly` );
+        } else {
+          Object.keys(values[idx]).forEach(( attr ) => {
+            assert.strictEqual( element.getAttribute(attr), values[idx][attr], `<link rel="${ rel }" ${ attr }="..." ... /> has not been rendered correctly` );
+          });
+        }
       });
     });
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,11 +91,22 @@ function parseTags ( tagName, props = {} ) {
         if (value === null ) {
           return;
         }
-        tags.push({
-          tagName,
-          [ groupKey ]: key,
-          [ contentKey ]: value
-        });
+        if (typeof value === 'string') {
+          tags.push({
+            tagName,
+            [ groupKey ]: key,
+            [ contentKey ]: value
+          });
+        } else {
+          const attrs = {
+            tagName,
+            [ groupKey ]: key
+          };
+          Object.keys( value ).forEach(( attr) => {
+            attrs[attr] = value[attr];
+          });
+          tags.push(attrs);
+        }
       });
     });
   });
@@ -141,7 +152,7 @@ function render ( meta = {}, opts ) {
   let i = 0;
   const tags = [];
 
-  function renderTag ( entry ) { 
+  function renderTag ( entry ) {
     const { tagName, ...attr } = entry;
 
     if ( tagName === 'meta' ) {
@@ -191,7 +202,12 @@ const DocumentMeta = React.createClass({
       React.PropTypes.objectOf(
         React.PropTypes.oneOfType([
           React.PropTypes.string,
-          React.PropTypes.arrayOf(React.PropTypes.string)
+          React.PropTypes.arrayOf(
+            React.PropTypes.oneOfType([
+              React.PropTypes.string,
+              React.PropTypes.objectOf(React.PropTypes.string)
+            ])
+          )
         ])
       )
     ),


### PR DESCRIPTION
Add support for objects passed to `link` option which makes possible more advanced meta tags like:

```html
<link rel="icon" type="image/png" sizes="32x32" href="/img/favicons/favicon-32x32.png">
<link rel="alternate" type="application/rss+xml" href="/foo/feed" />
<link rel="alternate" href="/url" hreflang="en-us" />
```

This PR is backwards compatible. You can still use the old format for simpler meta tags:

```javascript
var meta = {
    link: {
        rel: {
            stylesheet: [
                'http://domain.tld/css/vendor.css',
                'http://domain.tld/css/styles.css'
            ]
        }
    }
};
```

But for more advanced you can use this:

```javascript
var meta = {
    link: {
        rel: {
            alternate: [
                { href: '/alternate/us', hreflang: 'en-us' },
                { href: '/alternate/gb', hreflang: 'en-gb' }
            ]
        }
    }
};
```