### PR TITLE
Get rid on the extra div

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ class DocumentMeta extends Component {
     return count === 1 ? (
       React.Children.only(children)
     ) : count ? (
-      <div>{this.props.children}</div>
+      <React.Fragment>{this.props.children}</React.Fragment>
     ) : null;
   }
 }


### PR DESCRIPTION
There is not really a need for the wrapping div when there are multiple children. Putting these children in a React.Fragment removes the need for the wrapper.